### PR TITLE
HPCDATAMGM-2081: Deleting link gives invalid file location error

### DIFF
--- a/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcDataManagementBusServiceImpl.java
+++ b/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcDataManagementBusServiceImpl.java
@@ -1802,15 +1802,17 @@ public class HpcDataManagementBusServiceImpl implements HpcDataManagementBusServ
 			throw new HpcException("Unknown data transfer status", HpcErrorType.UNEXPECTED_ERROR);
 		}
 
-		// Validate the data object exists in the Archive.
-		HpcPathAttributes archivePathAttributes = dataTransferService.getPathAttributes(
-				systemGeneratedMetadata.getDataTransferType(), systemGeneratedMetadata.getArchiveLocation(), true,
-				systemGeneratedMetadata.getConfigurationId(), systemGeneratedMetadata.getS3ArchiveConfigurationId());
-		if (!archivePathAttributes.getExists() || !archivePathAttributes.getIsFile()) {
-			throw new HpcException("The data object was not found in the archive. S3 Archive ID: "
-					+ systemGeneratedMetadata.getS3ArchiveConfigurationId() + ". Archive location: "
-					+ systemGeneratedMetadata.getArchiveLocation().getFileContainerId() + ":"
-					+ systemGeneratedMetadata.getArchiveLocation().getFileId(), HpcErrorType.UNEXPECTED_ERROR);
+		// Validate the data object exists in the Archive. If it is not a softlink.
+		if (!registeredLink) {
+			HpcPathAttributes archivePathAttributes = dataTransferService.getPathAttributes(
+					systemGeneratedMetadata.getDataTransferType(), systemGeneratedMetadata.getArchiveLocation(), true,
+					systemGeneratedMetadata.getConfigurationId(), systemGeneratedMetadata.getS3ArchiveConfigurationId());
+			if (!archivePathAttributes.getExists() || !archivePathAttributes.getIsFile()) {
+				throw new HpcException("The data object was not found in the archive. S3 Archive ID: "
+						+ systemGeneratedMetadata.getS3ArchiveConfigurationId() + ". Archive location: "
+						+ systemGeneratedMetadata.getArchiveLocation().getFileContainerId() + ":"
+						+ systemGeneratedMetadata.getArchiveLocation().getFileId(), HpcErrorType.UNEXPECTED_ERROR);
+			}
 		}
 
 		// Validate the invoker is the owner of the data object.


### PR DESCRIPTION
Removing the validation to check if the data object exists in the Archive if it is a soft link.