### PR TITLE
HPCDATAMGM-2081: Deleting link gives invalid file location error

### DIFF
--- a/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcDataManagementBusServiceImpl.java
+++ b/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcDataManagementBusServiceImpl.java
@@ -1802,6 +1802,9 @@ public class HpcDataManagementBusServiceImpl implements HpcDataManagementBusServ
 			throw new HpcException("Unknown data transfer status", HpcErrorType.UNEXPECTED_ERROR);
 		}
 
+		// If it is a softlink, always perform a hard delete
+		force = registeredLink ? true: force;
+		
 		// Validate the data object exists in the Archive. If it is not a softlink.
 		if (!registeredLink) {
 			HpcPathAttributes archivePathAttributes = dataTransferService.getPathAttributes(


### PR DESCRIPTION
Change made for soft links to always perform a hard (force) delete without removing the underlying file.