### PR TITLE
HPCDATAMGM-2114-2115: Recording system deletion of a file in Audit table and additional check in auto deletion

### DIFF
--- a/src/hpc-server/hpc-app-service-api/src/main/java/gov/nih/nci/hpc/service/HpcDataManagementService.java
+++ b/src/hpc-server/hpc-app-service-api/src/main/java/gov/nih/nci/hpc/service/HpcDataManagementService.java
@@ -676,10 +676,11 @@ public interface HpcDataManagementService {
      * Get the original path of a deleted data object.
      *
      * @param path  The path of an deleted data object.
+     * @param archiveLocation The archive location of the deleted data object
      * @return The original path of the deleted data object
      * @throws HpcException on service failure.
      */
-    public String getOriginalPathForDeletedDataObject(String path);
+    public String getOriginalPathForDeletedDataObject(String path, HpcFileLocation archiveLocation) throws HpcException;
 
 	/**
 	 * Add an audit record in the DB for bulk metadata updates using query

--- a/src/hpc-server/hpc-app-service-impl/src/main/java/gov/nih/nci/hpc/service/impl/HpcDataManagementServiceImpl.java
+++ b/src/hpc-server/hpc-app-service-impl/src/main/java/gov/nih/nci/hpc/service/impl/HpcDataManagementServiceImpl.java
@@ -1293,6 +1293,10 @@ public class HpcDataManagementServiceImpl implements HpcDataManagementService {
 
 	@Override
 	public String getOriginalPathForDeletedDataObject(String path, HpcFileLocation archiveLocation) throws HpcException {
+	    // Validate archiveLocation is not null
+	    if (archiveLocation == null) {
+	        throw new HpcException("archiveLocation is null. Cannot determine the original path for the deleted data object.", HpcErrorType.DATA_MANAGEMENT_ERROR);
+	    }
 	  
 	    // Check if it is a deleted archive record
 	    if (path == null || !path.startsWith(deletedBasePath)) {

--- a/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcDataManagementBusServiceImpl.java
+++ b/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcDataManagementBusServiceImpl.java
@@ -1849,7 +1849,8 @@ public class HpcDataManagementBusServiceImpl implements HpcDataManagementBusServ
 
 
 		//Hard delete is permitted only for system administrators
-		if( !HpcUserRole.SYSTEM_ADMIN.equals(invoker.getUserRole()) ) {
+		if(!invoker.getAuthenticationType().equals(HpcAuthenticationType.SYSTEM_ACCOUNT) && 
+		    !HpcUserRole.SYSTEM_ADMIN.equals(invoker.getUserRole()) ) {
 			if(!registeredLink && force) {
 				String message = "Hard delete is permitted for system administrators only";
 				logger.error(message);
@@ -1955,6 +1956,7 @@ public class HpcDataManagementBusServiceImpl implements HpcDataManagementBusServ
 				? HpcAuditRequestType.DELETE_DATA_OBJECT
 				: HpcAuditRequestType.STORAGE_RECOVERY;
 		String userId = storageRecoveryConfiguration == null ? null : "storage-recovery-task";
+		userId = userId == null && invoker.getAuthenticationType().equals(HpcAuthenticationType.SYSTEM_ACCOUNT) ? "remove-deleted-dataobjects-task" : userId;
 		dataManagementService.addAuditRecord(path, auditRequestType, metadataEntries, null,
 				systemGeneratedMetadata.getArchiveLocation(), dataObjectDeleteResponse.getDataManagementDeleteStatus(),
 				dataObjectDeleteResponse.getArchiveDeleteStatus(), dataObjectDeleteResponse.getMessage(), userId,

--- a/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcDataManagementBusServiceImpl.java
+++ b/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcDataManagementBusServiceImpl.java
@@ -1848,7 +1848,7 @@ public class HpcDataManagementBusServiceImpl implements HpcDataManagementBusServ
 		}
 
 
-		//Hard delete is permitted only for system administrators
+		// Hard delete is permitted for system administrators and system accounts
 		if(!invoker.getAuthenticationType().equals(HpcAuthenticationType.SYSTEM_ACCOUNT) && 
 		    !HpcUserRole.SYSTEM_ADMIN.equals(invoker.getUserRole()) ) {
 			if(!registeredLink && force) {

--- a/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcDataManagementBusServiceImpl.java
+++ b/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcDataManagementBusServiceImpl.java
@@ -1955,6 +1955,7 @@ public class HpcDataManagementBusServiceImpl implements HpcDataManagementBusServ
 		HpcAuditRequestType auditRequestType = storageRecoveryConfiguration == null
 				? HpcAuditRequestType.DELETE_DATA_OBJECT
 				: HpcAuditRequestType.STORAGE_RECOVERY;
+		// If this is a system task, pass in the userId string to record in the audit table.
 		String userId = storageRecoveryConfiguration == null ? null : "storage-recovery-task";
 		userId = userId == null && invoker.getAuthenticationType().equals(HpcAuthenticationType.SYSTEM_ACCOUNT) ? "remove-deleted-dataobjects-task" : userId;
 		dataManagementService.addAuditRecord(path, auditRequestType, metadataEntries, null,

--- a/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcSystemBusServiceImpl.java
+++ b/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcSystemBusServiceImpl.java
@@ -3338,7 +3338,10 @@ public class HpcSystemBusServiceImpl implements HpcSystemBusService {
 			if (dataManagementService.deletedDataObjectExpired(systemGeneratedMetadata.getDeletedDate())) {
 			    
 			    // Check if there is a record for the original path
-			    String originalPath = dataManagementService.getOriginalPathForDeletedDataObject(path);
+			    // Get the original path by removing the deleted archive base path,
+			    // and remove the timestamp appended to the original path if it was soft deleted more than once
+			    String originalPath = dataManagementService.getOriginalPathForDeletedDataObject(path,
+			        systemGeneratedMetadata.getArchiveLocation());
 			    HpcDataObject originalDataObject = dataManagementService.getDataObject(originalPath);
 			    
 			    // Check if the deleted data object can be permanently removed


### PR DESCRIPTION
Please review the changes to record the system deletion of a file in HPC_DATA_MANAGEMENT_AUDIT table and adding additional checks to the auto deletion process when the soft deleted record has a timestamp appended to the original path (occurs when soft deleted more than once).
