### PR TITLE
HPCDATAMGM-2124: Fix total items count for retried download transaction

### DIFF
--- a/src/hpc-web/src/main/java/gov/nih/nci/hpc/web/controller/HpcDownloadTaskController.java
+++ b/src/hpc-web/src/main/java/gov/nih/nci/hpc/web/controller/HpcDownloadTaskController.java
@@ -449,9 +449,7 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 	//If previousTasks is not empty, update the message to include the items in it
 	if(!previousTasks.isEmpty()) {
 		completedItemsCount = getCompletedItemsCount(downloadTask, previousTasks);
-		totalItemsCount = completedItemsCount +
-				  (downloadTask.getCanceledItems() != null ? downloadTask.getCanceledItems().size() : 0)
-				  + (downloadTask.getFailedItems() != null ? downloadTask.getFailedItems().size() : 0);
+		totalItemsCount = getTotalItemsCount(downloadTask, completedItemsCount);
 		//Override the server message
 		String message = completedItemsCount + " items downloaded successfully out of " + totalItemsCount;
 		downloadTask.setMessage(message);
@@ -518,9 +516,7 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 	//If previousTasks is not empty, update the message to include the items in it
 	if(!previousTasks.isEmpty()) {
 		completedItemsCount = getCompletedItemsCount(downloadTask, previousTasks);
-		totalItemsCount = completedItemsCount +
-				(downloadTask.getCanceledItems() != null ? downloadTask.getCanceledItems().size() : 0)
-				+ (downloadTask.getFailedItems() != null ? downloadTask.getFailedItems().size() : 0);
+		totalItemsCount = getTotalItemsCount(downloadTask, completedItemsCount);
 		//Override the server message
 		String message = completedItemsCount + " items downloaded successfully out of " + totalItemsCount;
 		downloadTask.setMessage(message);
@@ -561,9 +557,7 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 		//If previousTasks is not empty, update the message to include the items in it
 		if(!previousTasks.isEmpty()) {
 			completedItemsCount = getCompletedItemsCount(downloadTask, previousTasks);
-			totalItemsCount = completedItemsCount +
-			(downloadTask.getCanceledItems() != null ? downloadTask.getCanceledItems().size() : 0)
-			+ (downloadTask.getFailedItems() != null ? downloadTask.getFailedItems().size() : 0);
+			totalItemsCount = getTotalItemsCount(downloadTask, completedItemsCount);
 			//Override the server message
 			String message = completedItemsCount + " items downloaded successfully out of " + totalItemsCount;
 			downloadTask.setMessage(message);
@@ -575,6 +569,14 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 	    model.addAttribute("hpcDataObjectsDownloadBytesTransferred", MiscUtil.addHumanReadableSize(Long.toString(completedItemsSize), true));
 	    model.addAttribute("pendingItemsCount", totalItemsCount - completedItemsCount);
 	    return "dataobjectsdownloadtask";
+  }
+
+
+  private int getTotalItemsCount(HpcCollectionDownloadStatusDTO downloadTask, int completedItemsCount) {
+
+      return (completedItemsCount +
+          (downloadTask.getCanceledItems() != null ? downloadTask.getCanceledItems().size() : 0)
+          + (downloadTask.getFailedItems() != null ? downloadTask.getFailedItems().size() : 0) );
   }
 
 

--- a/src/hpc-web/src/main/java/gov/nih/nci/hpc/web/controller/HpcDownloadTaskController.java
+++ b/src/hpc-web/src/main/java/gov/nih/nci/hpc/web/controller/HpcDownloadTaskController.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.stereotype.Controller;
@@ -448,7 +449,9 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 	//If previousTasks is not empty, update the message to include the items in it
 	if(!previousTasks.isEmpty()) {
 		completedItemsCount = getCompletedItemsCount(downloadTask, previousTasks);
-		totalItemsCount = getTotalItemsCount(downloadTask, previousTasks);
+		totalItemsCount = completedItemsCount +
+				  (downloadTask.getCanceledItems() != null ? downloadTask.getCanceledItems().size() : 0)
+				  + (downloadTask.getFailedItems() != null ? downloadTask.getFailedItems().size() : 0);
 		//Override the server message
 		String message = completedItemsCount + " items downloaded successfully out of " + totalItemsCount;
 		downloadTask.setMessage(message);
@@ -515,7 +518,9 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 	//If previousTasks is not empty, update the message to include the items in it
 	if(!previousTasks.isEmpty()) {
 		completedItemsCount = getCompletedItemsCount(downloadTask, previousTasks);
-		totalItemsCount = getTotalItemsCount(downloadTask, previousTasks);
+		totalItemsCount = completedItemsCount +
+				(downloadTask.getCanceledItems() != null ? downloadTask.getCanceledItems().size() : 0)
+				+ (downloadTask.getFailedItems() != null ? downloadTask.getFailedItems().size() : 0);
 		//Override the server message
 		String message = completedItemsCount + " items downloaded successfully out of " + totalItemsCount;
 		downloadTask.setMessage(message);
@@ -556,7 +561,9 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 		//If previousTasks is not empty, update the message to include the items in it
 		if(!previousTasks.isEmpty()) {
 			completedItemsCount = getCompletedItemsCount(downloadTask, previousTasks);
-			totalItemsCount = getTotalItemsCount(downloadTask, previousTasks);
+			totalItemsCount = completedItemsCount +
+			(downloadTask.getCanceledItems() != null ? downloadTask.getCanceledItems().size() : 0)
+			+ (downloadTask.getFailedItems() != null ? downloadTask.getFailedItems().size() : 0);
 			//Override the server message
 			String message = completedItemsCount + " items downloaded successfully out of " + totalItemsCount;
 			downloadTask.setMessage(message);
@@ -568,22 +575,6 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 	    model.addAttribute("hpcDataObjectsDownloadBytesTransferred", MiscUtil.addHumanReadableSize(Long.toString(completedItemsSize), true));
 	    model.addAttribute("pendingItemsCount", totalItemsCount - completedItemsCount);
 	    return "dataobjectsdownloadtask";
-  }
-
-
-  private int getTotalItemsCount(HpcCollectionDownloadStatusDTO downloadTask, List<HpcCollectionDownloadStatusDTO> previousTasks) {
-	  int totalDownloadTaskItemsCount = 0;
-	  List<HpcCollectionDownloadStatusDTO> parentPreviousTasks = null;
-	  if(!previousTasks.isEmpty()) {
-		  HpcCollectionDownloadStatusDTO previousTask = previousTasks.get(0);
-		  totalDownloadTaskItemsCount +=
-				  (previousTask.getCanceledItems() != null ? previousTask.getCanceledItems().size() : 0)
-				  + (previousTask.getFailedItems() != null ? previousTask.getFailedItems().size() : 0);
-		  parentPreviousTasks = new ArrayList<>(previousTasks);
-		  parentPreviousTasks.remove(0);
-	  }
-
-	  return totalDownloadTaskItemsCount + getCompletedItemsCount(previousTasks.get(0), parentPreviousTasks);
   }
 
 


### PR DESCRIPTION
Web application is calculating the total count incorrectly for retried transactions. It uses the failed and cancelled transactions from the previous task(s). Instead it should use the failed and cancelled transactions from the current task, since failure count may be different. Note that if cancelled transactions are present, the total will not include the data objects that did not get broken down because there is no way to determine that. 