### PR TITLE
HPCDATAMGM-2127: Wildcard search for "path" as attribute name doesn't

### DIFF
--- a/src/hpc-server/hpc-app-service-impl/src/main/java/gov/nih/nci/hpc/service/impl/HpcDomainValidator.java
+++ b/src/hpc-server/hpc-app-service-impl/src/main/java/gov/nih/nci/hpc/service/impl/HpcDomainValidator.java
@@ -549,7 +549,7 @@ public class HpcDomainValidator {
 				validationResult.setMessage("attributeMatch provided w/ path-operator [" + metadataQuery + "]");
 				return validationResult;
 			} else if (dataManagementProxy != null) {
-				// If wild card is at the beginning of the path, remove the leading slash to include base path following the slash.
+				// If wildcard is at the beginning of the path, remove the leading slash to include the base path.
 				String path = metadataQuery.getValue().startsWith("%/") ? "%" + metadataQuery.getValue().substring(2)
 						: metadataQuery.getValue();
 				metadataQuery.setValue(dataManagementProxy.getAbsolutePath(toNormalizedPath(path)));


### PR DESCRIPTION
Please review when you get a chance. Previously, if user supplied %/HiTIF_Archive/% as path, it searched for /tempZone/home/%/HiTIF_Archive/%.
This did not pick up any results from the base path /HiTIF_Archive.