### PR TITLE
HPCDATAMGM-2130 REST-API to update System Metadata for System Administrators

### DIFF
--- a/src/hpc-server/hpc-app-service-impl/src/main/java/gov/nih/nci/hpc/service/impl/HpcMetadataServiceImpl.java
+++ b/src/hpc-server/hpc-app-service-impl/src/main/java/gov/nih/nci/hpc/service/impl/HpcMetadataServiceImpl.java
@@ -231,7 +231,8 @@ public class HpcMetadataServiceImpl implements HpcMetadataService {
 
 		// Validate collection type is not in the update request.
 		List<HpcMetadataEntry> existingMetadataEntries = metadataRetriever.getCollectionMetadata(path);
-		validateCollectionTypeUpdate(existingMetadataEntries, metadataEntries);
+		if(!allowSystemMetadata)
+			validateCollectionTypeUpdate(existingMetadataEntries, metadataEntries);
 
 		// Validate the metadata.
 		metadataValidator.validateCollectionMetadata(configurationId, existingMetadataEntries, metadataEntries, allowSystemMetadata);

--- a/src/hpc-server/hpc-app-service-impl/src/main/java/gov/nih/nci/hpc/service/impl/HpcMetadataServiceImpl.java
+++ b/src/hpc-server/hpc-app-service-impl/src/main/java/gov/nih/nci/hpc/service/impl/HpcMetadataServiceImpl.java
@@ -231,8 +231,9 @@ public class HpcMetadataServiceImpl implements HpcMetadataService {
 
 		// Validate collection type is not in the update request.
 		List<HpcMetadataEntry> existingMetadataEntries = metadataRetriever.getCollectionMetadata(path);
-		if(!allowSystemMetadata)
+		if (!allowSystemMetadata) {
 			validateCollectionTypeUpdate(existingMetadataEntries, metadataEntries);
+		}
 
 		// Validate the metadata.
 		metadataValidator.validateCollectionMetadata(configurationId, existingMetadataEntries, metadataEntries, allowSystemMetadata);

--- a/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcDataManagementBusServiceImpl.java
+++ b/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcDataManagementBusServiceImpl.java
@@ -3674,10 +3674,13 @@ public class HpcDataManagementBusServiceImpl implements HpcDataManagementBusServ
 		boolean updated = true;
 		String message = null;
 		try {
+			//If system admin, allow system metadata update, otherwise only allow user metadata update.
+			HpcRequestInvoker invoker = securityService.getRequestInvoker();
+			boolean allowSystemMetadataUpdate = HpcUserRole.SYSTEM_ADMIN.equals(invoker.getUserRole());
 			if (!metadataContained(metadataEntries, metadataBefore.getSelfMetadataEntries())) {
 				synchronized (this) {
 					metadataService.updateCollectionMetadata(path, metadataEntries,
-							systemGeneratedMetadata.getConfigurationId(), false);
+							systemGeneratedMetadata.getConfigurationId(), allowSystemMetadataUpdate);
 				}
 			} else {
 				logger.info(
@@ -3736,12 +3739,16 @@ public class HpcDataManagementBusServiceImpl implements HpcDataManagementBusServ
 					HpcErrorType.REQUEST_REJECTED).withSuppressStackTraceLogging(true);
 		}
 
+		
 		// Update the metadata.
 		boolean updated = true;
 		String message = null;
 		try {
+			//If system admin, allow system metadata update, otherwise only allow user metadata update.
+			HpcRequestInvoker invoker = securityService.getRequestInvoker();
+			boolean allowSystemMetadataUpdate = HpcUserRole.SYSTEM_ADMIN.equals(invoker.getUserRole());
 			metadataService.updateDataObjectMetadata(path, metadataEntries,
-					systemGeneratedMetadata.getConfigurationId(), collectionType, false, false);
+					systemGeneratedMetadata.getConfigurationId(), collectionType, false, allowSystemMetadataUpdate);
 
 		} catch (HpcException e) {
 			// Data object metadata update failed. Capture this in the audit record.


### PR DESCRIPTION
Allows System Administrators of DME to add/update System Metadata on DME using the existing APIs including collection_type metadata.