### PR TITLE
HPCDAYAMGM-2187: Display download size on the Down Task Details page

### DIFF
--- a/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcDataManagementBusServiceImpl.java
+++ b/src/hpc-server/hpc-bus-service-impl/src/main/java/gov/nih/nci/hpc/bus/impl/HpcDataManagementBusServiceImpl.java
@@ -1729,6 +1729,7 @@ public class HpcDataManagementBusServiceImpl implements HpcDataManagementBusServ
 			downloadStatus.setRetryUserId(taskStatus.getDataObjectDownloadTask().getRetryUserId());
 			downloadStatus.setRetryTaskId(taskStatus.getDataObjectDownloadTask().getRetryTaskId());
 			downloadStatus.setPriority(taskStatus.getDataObjectDownloadTask().getPriority());
+			downloadStatus.setDataSize(taskStatus.getDataObjectDownloadTask().getSize());
 		} else {
 			// Download completed or failed. Populate the DTO accordingly.
 			downloadStatus.setPath(taskStatus.getResult().getPath());
@@ -1750,6 +1751,7 @@ public class HpcDataManagementBusServiceImpl implements HpcDataManagementBusServ
 							&& StringUtils.isNotEmpty(taskStatus.getResult().getGoogleDriveDownloadDestination().getAccessToken()))
 							|| (taskStatus.getResult().getGoogleCloudStorageDestination() != null
 									&& StringUtils.isNotEmpty(taskStatus.getResult().getGoogleCloudStorageDestination().getAccessToken())));
+			downloadStatus.setDataSize(taskStatus.getResult().getSize());
 		}
 
 		return downloadStatus;
@@ -3022,6 +3024,7 @@ public class HpcDataManagementBusServiceImpl implements HpcDataManagementBusServ
 			}
 			downloadStatus.setPriority(taskStatus.getCollectionDownloadTask().getPriority());
 			downloadStatus.setCancellationRequested(dataTransferService.getCollectionDownloadTaskCancellationRequested(taskId));
+		    downloadStatus.setDataSize(taskStatus.getCollectionDownloadTask().getDataSize());
 			
 			// Get the status of the individual data object download tasks if the collection status
 			// is not yet ACTIVE, because the collection items field does not get populated before that
@@ -3115,6 +3118,7 @@ public class HpcDataManagementBusServiceImpl implements HpcDataManagementBusServ
 							&& StringUtils.isNotEmpty(taskStatus.getResult().getGoogleDriveDownloadDestination().getAccessToken()))
 							|| (taskStatus.getResult().getGoogleCloudStorageDestination() != null
 									&& StringUtils.isNotEmpty(taskStatus.getResult().getGoogleCloudStorageDestination().getAccessToken())));
+			downloadStatus.setDataSize(taskStatus.getResult().getSize());
 		}
 
 		return downloadStatus;

--- a/src/hpc-server/hpc-dto/src/main/resources/schema/HpcDataManagement.xsd
+++ b/src/hpc-server/hpc-dto/src/main/resources/schema/HpcDataManagement.xsd
@@ -479,6 +479,7 @@
 				<xsd:element name="retryTaskId" type="xsd:string" />
 				<xsd:element name="retryUserId" type="xsd:string" />
 				<xsd:element name="priority" type="xsd:int" minOccurs="0" />
+				<xsd:element name="dataSize" type="xsd:long" minOccurs="0" />
 				<xsd:element name="retryable" type="xsd:boolean" />
 			</xsd:sequence>
 		</xsd:complexType>
@@ -554,6 +555,7 @@
 					type="hpc-dto-datamanagement:HpcCollectionResultSummaryDTO"
 					minOccurs="0" maxOccurs="unbounded" />
 				<xsd:element name="priority" type="xsd:int" minOccurs="0" />
+				<xsd:element name="dataSize" type="xsd:long" minOccurs="0" />
 				<xsd:element name="retryable" type="xsd:boolean" />
 			</xsd:sequence>
 		</xsd:complexType>

--- a/src/hpc-web/src/main/java/gov/nih/nci/hpc/web/controller/HpcDownloadTaskController.java
+++ b/src/hpc-web/src/main/java/gov/nih/nci/hpc/web/controller/HpcDownloadTaskController.java
@@ -420,6 +420,7 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 		retry = false;
 	}
 	
+	model.addAttribute("downloadSize", MiscUtil.addHumanReadableSize(Long.toString(downloadTask.getDataSize()), true));
 	model.addAttribute("hpcBulkDataObjectDownloadRetry", retry);
     return "dataobjectdownloadtask";
   }
@@ -482,6 +483,7 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 	model.addAttribute("hpcBulkDataObjectDownloadRetry", retry);
     model.addAttribute("hpcDataObjectsDownloadStatusDTO", downloadTask);
     model.addAttribute("hpcOrigDataObjectsDownloadStatusDTOs", previousTasks);
+    model.addAttribute("downloadSize", MiscUtil.addHumanReadableSize(Long.toString(downloadTask.getDataSize()), true));
     model.addAttribute("hpcDataObjectsDownloadBytesTransferred", MiscUtil.addHumanReadableSize(Long.toString(completedItemsSize), true));
     model.addAttribute("pendingItemsCount", totalItemsCount - completedItemsCount);
     return "dataobjectsdownloadtask";
@@ -550,6 +552,7 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 	model.addAttribute("hpcBulkDataObjectDownloadRetry", retry);
     model.addAttribute("hpcDataObjectsDownloadStatusDTO", downloadTask);
     model.addAttribute("hpcOrigDataObjectsDownloadStatusDTOs", previousTasks);
+    model.addAttribute("downloadSize", MiscUtil.addHumanReadableSize(Long.toString(downloadTask.getDataSize()), true));
     model.addAttribute("hpcDataObjectsDownloadBytesTransferred", MiscUtil.addHumanReadableSize(Long.toString(completedItemsSize), true));
     model.addAttribute("pendingItemsCount", totalItemsCount - completedItemsCount);
     return "dataobjectsdownloadtask";
@@ -601,6 +604,7 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 		model.addAttribute("hpcBulkDataObjectDownloadRetry", retry);
 	    model.addAttribute("hpcDataObjectsDownloadStatusDTO", downloadTask);
 	    model.addAttribute("hpcOrigDataObjectsDownloadStatusDTOs", previousTasks);
+	    model.addAttribute("downloadSize", MiscUtil.addHumanReadableSize(Long.toString(downloadTask.getDataSize()), true));
 	    model.addAttribute("hpcDataObjectsDownloadBytesTransferred", MiscUtil.addHumanReadableSize(Long.toString(completedItemsSize), true));
 	    model.addAttribute("pendingItemsCount", totalItemsCount - completedItemsCount);
 	    return "dataobjectsdownloadtask";

--- a/src/hpc-web/src/main/java/gov/nih/nci/hpc/web/controller/HpcDownloadTaskController.java
+++ b/src/hpc-web/src/main/java/gov/nih/nci/hpc/web/controller/HpcDownloadTaskController.java
@@ -420,7 +420,11 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 		retry = false;
 	}
 	
-	model.addAttribute("downloadSize", MiscUtil.addHumanReadableSize(Long.toString(downloadTask.getDataSize()), true));
+    Long dataSize = downloadTask.getDataSize();
+    if (dataSize != null) {
+      model.addAttribute("downloadSize",
+          MiscUtil.addHumanReadableSize(Long.toString(dataSize), true));
+    }
 	model.addAttribute("hpcBulkDataObjectDownloadRetry", retry);
     return "dataobjectdownloadtask";
   }
@@ -483,7 +487,10 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 	model.addAttribute("hpcBulkDataObjectDownloadRetry", retry);
     model.addAttribute("hpcDataObjectsDownloadStatusDTO", downloadTask);
     model.addAttribute("hpcOrigDataObjectsDownloadStatusDTOs", previousTasks);
-    model.addAttribute("downloadSize", MiscUtil.addHumanReadableSize(Long.toString(downloadTask.getDataSize()), true));
+    String downloadSize = downloadTask.getDataSize() != null
+        ? MiscUtil.addHumanReadableSize(Long.toString(downloadTask.getDataSize()), true)
+        : null;
+    model.addAttribute("downloadSize", downloadSize);
     model.addAttribute("hpcDataObjectsDownloadBytesTransferred", MiscUtil.addHumanReadableSize(Long.toString(completedItemsSize), true));
     model.addAttribute("pendingItemsCount", totalItemsCount - completedItemsCount);
     return "dataobjectsdownloadtask";
@@ -552,7 +559,10 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 	model.addAttribute("hpcBulkDataObjectDownloadRetry", retry);
     model.addAttribute("hpcDataObjectsDownloadStatusDTO", downloadTask);
     model.addAttribute("hpcOrigDataObjectsDownloadStatusDTOs", previousTasks);
-    model.addAttribute("downloadSize", MiscUtil.addHumanReadableSize(Long.toString(downloadTask.getDataSize()), true));
+    model.addAttribute("downloadSize",
+        downloadTask.getDataSize() != null
+            ? MiscUtil.addHumanReadableSize(Long.toString(downloadTask.getDataSize()), true)
+            : null);
     model.addAttribute("hpcDataObjectsDownloadBytesTransferred", MiscUtil.addHumanReadableSize(Long.toString(completedItemsSize), true));
     model.addAttribute("pendingItemsCount", totalItemsCount - completedItemsCount);
     return "dataobjectsdownloadtask";
@@ -604,7 +614,10 @@ public class HpcDownloadTaskController extends AbstractHpcController {
 		model.addAttribute("hpcBulkDataObjectDownloadRetry", retry);
 	    model.addAttribute("hpcDataObjectsDownloadStatusDTO", downloadTask);
 	    model.addAttribute("hpcOrigDataObjectsDownloadStatusDTOs", previousTasks);
-	    model.addAttribute("downloadSize", MiscUtil.addHumanReadableSize(Long.toString(downloadTask.getDataSize()), true));
+	    model.addAttribute("downloadSize",
+	        downloadTask.getDataSize() != null
+	            ? MiscUtil.addHumanReadableSize(Long.toString(downloadTask.getDataSize()), true)
+	            : null);
 	    model.addAttribute("hpcDataObjectsDownloadBytesTransferred", MiscUtil.addHumanReadableSize(Long.toString(completedItemsSize), true));
 	    model.addAttribute("pendingItemsCount", totalItemsCount - completedItemsCount);
 	    return "dataobjectsdownloadtask";

--- a/src/hpc-web/src/main/resources/templates/dataobjectdownloadtask.html
+++ b/src/hpc-web/src/main/resources/templates/dataobjectdownloadtask.html
@@ -178,6 +178,11 @@
 												for="${hpcDataObjectDownloadStatusDTO.getDestinationLocation().getFileId()}"
 												th:text="${hpcDataObjectDownloadStatusDTO.getDestinationLocation().getFileId()}"></label>
 										</div>
+										<div class="col-md-12 form-group" th:if="${downloadSize != null}">
+											<label for="Name">Download Size:</label> <label
+												for="${downloadSize}"
+												th:text="${downloadSize}"></label>
+										</div>
 										<div class="col-md-12 form-group" th:if="${hpcDataObjectDownloadStatusDTO.getResult() != null}">
 											<label for="Name">Transfer Status:</label> <label id="regComplete"
 												for="${hpcDataObjectDownloadStatusDTO.getResult()}"

--- a/src/hpc-web/src/main/resources/templates/dataobjectdownloadtask.html
+++ b/src/hpc-web/src/main/resources/templates/dataobjectdownloadtask.html
@@ -179,9 +179,8 @@
 												th:text="${hpcDataObjectDownloadStatusDTO.getDestinationLocation().getFileId()}"></label>
 										</div>
 										<div class="col-md-12 form-group" th:if="${downloadSize != null}">
-											<label for="Name">Download Size:</label> <label
-												for="${downloadSize}"
-												th:text="${downloadSize}"></label>
+											<label for="Name">Download Size:</label> <span
+												th:text="${downloadSize}"></span>
 										</div>
 										<div class="col-md-12 form-group" th:if="${hpcDataObjectDownloadStatusDTO.getResult() != null}">
 											<label for="Name">Transfer Status:</label> <label id="regComplete"

--- a/src/hpc-web/src/main/resources/templates/dataobjectsdownloadtask.html
+++ b/src/hpc-web/src/main/resources/templates/dataobjectsdownloadtask.html
@@ -194,6 +194,11 @@
 											for="${hpcDataObjectsDownloadStatusDTO.getDestinationLocation().getFileId()}"
 											th:text="${hpcDataObjectsDownloadStatusDTO.getDestinationLocation().getFileId()}"></label>
 									</div>
+									<div class="col-md-12 form-group" th:if="${downloadSize != null}">
+										<label for="Name">Download Size:</label> <label
+											for="${downloadSize}"
+											th:text="${downloadSize}"></label>
+									</div>
 									<div class="col-md-12 form-group" th:if="${hpcDataObjectsDownloadStatusDTO.getResult() != null}">
 										<label for="Name">Transfer Status:</label> <label id="regComplete"
 											for="${hpcDataObjectsDownloadStatusDTO.getResult()}"


### PR DESCRIPTION
The ticket is to add a new column 'Download Size' on the Download Task Details page of the DME web application. It will display the total size of the requested download path or paths for DataObject, Collection, List of DataObjects, and List of Collections. The size will be displayed in Human readable form, measured in SI units as with the display in other parts of DME.  