### PR TITLE
HPCDATAMGM-2192: Removing unnecessary multipart/form-data.

### DIFF
--- a/src/hpc-web/src/main/resources/templates/collectionsearchresult.html
+++ b/src/hpc-web/src/main/resources/templates/collectionsearchresult.html
@@ -456,7 +456,7 @@ app.controller('MainCtrl', ['$scope', '$http', '$interval', 'uiGridGroupingConst
 						</div>
 					<form class="form-horizontal" id="simplesearchform" action="#"
 						role="form" th:action="@{/criteria}" th:object="${hpcSearch}"
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="actionType" name="actionType" value="pagination"/>
 						<input type="hidden" id="pageNumber" name="pageNumber"/>
 						<input type="hidden" id="pageSize" name="pageSize"/>
@@ -465,7 +465,7 @@ app.controller('MainCtrl', ['$scope', '$http', '$interval', 'uiGridGroupingConst
 					</form> 
 					<form class="form-horizontal" id="downloadFilesform" action="#"
 						role="form" th:action="@{/downloadfiles}" 
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="selectedFilePaths1" name="selectedFilePaths" value=""/>
 						<input type="hidden" id="downloadType" name="downloadType" value=""/>
 						<input type="hidden" id="searchType" name="searchType" value=""/>
@@ -475,7 +475,7 @@ app.controller('MainCtrl', ['$scope', '$http', '$interval', 'uiGridGroupingConst
 					</form>
 					<form class="form-horizontal" id="bulkPermissionsform" action="#"
 						role="form" th:action="@{/bulkpermissions}" 
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="selectedFilePaths2" name="selectedFilePaths" value=""/>
 						<input type="hidden" id="downloadType2" name="downloadType" value=""/>
 						<input type="hidden" id="searchType2" name="searchType" value=""/>
@@ -485,7 +485,7 @@ app.controller('MainCtrl', ['$scope', '$http', '$interval', 'uiGridGroupingConst
 					</form> 
 					<form class="form-horizontal" id="bulkMetadataform" action="#"
 						role="form" th:action="@{/bulkupdatemetadata}"
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="selectedFilePaths3" name="selectedFilePaths" value=""/>
 						<input type="hidden" id="downloadType3" name="downloadType" value=""/>
 						<input type="hidden" id="searchType3" name="searchType" value=""/>
@@ -497,7 +497,7 @@ app.controller('MainCtrl', ['$scope', '$http', '$interval', 'uiGridGroupingConst
 					</form>
 					<form class="form-horizontal" id="editsearchform" action="#"
 						role="form" th:action="@{/editSearch}" th:object="${hpcSearch}"
-						method="post" enctype="multipart/form-data">
+						method="post">
 					</form> 
 					</div>
 

--- a/src/hpc-web/src/main/resources/templates/collectionsearchresultdetail.html
+++ b/src/hpc-web/src/main/resources/templates/collectionsearchresultdetail.html
@@ -754,7 +754,7 @@ window.onclick = function(event) {
 					</div>
 					<form class="form-horizontal" id="simplesearchform" action="#"
 						role="form" th:action="@{/criteria}" th:object="${hpcSearch}"
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="actionType" name="actionType" value="pagination"/>
 						<input type="hidden" id="pageNumber" name="pageNumber"/>
 						<input type="hidden" id="pageSize" name="pageSize"/>
@@ -767,7 +767,7 @@ window.onclick = function(event) {
 					</form> 
 					<form class="form-horizontal" id="downloadFilesform" action="#"
 						role="form" th:action="@{/downloadfiles}"
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="selectedFilePaths1" name="selectedFilePaths" value=""/>
 						<input type="hidden" id="downloadType" name="downloadType" value=""/>
 						<input type="hidden" id="searchType" name="searchType" value=""/>
@@ -781,7 +781,7 @@ window.onclick = function(event) {
 					</form>
 					<form class="form-horizontal" id="bulkPermissionsform" action="#"
 						role="form" th:action="@{/bulkpermissions}" 
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="selectedFilePaths2" name="selectedFilePaths" value=""/>
 						<input type="hidden" id="downloadType2" name="downloadType" value=""/>
 						<input type="hidden" id="searchType2" name="searchType" value=""/>
@@ -795,7 +795,7 @@ window.onclick = function(event) {
 					</form> 
 					<form class="form-horizontal" id="bulkMetadataform" action="#"
 						role="form" th:action="@{/bulkupdatemetadata}"
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="selectedFilePaths3" name="selectedFilePaths" value=""/>
 						<input type="hidden" id="downloadType3" name="downloadType" value=""/>
 						<input type="hidden" id="searchType3" name="searchType" value=""/>
@@ -811,7 +811,7 @@ window.onclick = function(event) {
 					</form>
 					<form class="form-horizontal" id="editsearchform" action="#"
 						role="form" th:action="@{/editSearch}" th:object="${hpcSearch}"
-						method="post" enctype="multipart/form-data">
+						method="post">
 					</form> 
 				</div>
 				<!--/col-->

--- a/src/hpc-web/src/main/resources/templates/criteria.html
+++ b/src/hpc-web/src/main/resources/templates/criteria.html
@@ -80,7 +80,7 @@
 					</div>
 					<form class="form-horizontal" id="simplesearchform" action="#"
 						role="form" th:action="@{/criteria}" th:object="${hpcSearch}"
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<div class="form-group">
 							<label class="control-label col-sm-2" for="level">Search
 								Type</label>

--- a/src/hpc-web/src/main/resources/templates/dataobjectsearchresult.html
+++ b/src/hpc-web/src/main/resources/templates/dataobjectsearchresult.html
@@ -525,7 +525,7 @@
 					</div>
 					<form class="form-horizontal" id="simplesearchform" action="#"
 						role="form" th:action="@{/criteria}" th:object="${hpcSearch}"
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="actionType" name="actionType" value="pagination"/>
 						<input type="hidden" id="pageNumber" name="pageNumber"/>
 						<input type="hidden" id="pageSize" name="pageSize"/>
@@ -534,7 +534,7 @@
 					</form> 
 					<form class="form-horizontal" id="downloadFilesform" action="#"
 						role="form" th:action="@{/downloadfiles}" 
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="selectedFilePaths1" name="selectedFilePaths" value=""/>
 						<input type="hidden" id="downloadType" name="downloadType" value=""/>
 						<input type="hidden" id="searchType" name="searchType" value=""/>
@@ -544,7 +544,7 @@
 					</form> 
 					<form class="form-horizontal" id="linkFilesform" action="#"
 						role="form" th:action="@{/linkfiles}" 
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="selectedFilePaths2" name="selectedFilePaths" value=""/>
 						<input type="hidden" id="searchType2" name="searchType" value=""/>
 						<input type="hidden" id="pageNumber2" name="pageNumber"/>
@@ -553,7 +553,7 @@
 					</form> 
 					<form class="form-horizontal" id="bulkPermissionsform" action="#"
 						role="form" th:action="@{/bulkpermissions}" 
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="selectedFilePaths3" name="selectedFilePaths" value=""/>
 						<input type="hidden" id="downloadType3" name="downloadType" value=""/>
 						<input type="hidden" id="searchType3" name="searchType" value=""/>
@@ -563,7 +563,7 @@
 					</form> 
 					<form class="form-horizontal" id="bulkMetadataform" action="#"
 						role="form" th:action="@{/bulkupdatemetadata}"
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="selectedFilePaths4" name="selectedFilePaths" value=""/>
 						<input type="hidden" id="downloadType4" name="downloadType" value=""/>
 						<input type="hidden" id="searchType4" name="searchType" value=""/>
@@ -575,7 +575,7 @@
 					</form>
 					<form class="form-horizontal" id="editsearchform" action="#"
 						role="form" th:action="@{/editSearch}" th:object="${hpcSearch}"
-						method="post" enctype="multipart/form-data">
+						method="post">
 					</form> 
 				</div>
 				<!--/col-->

--- a/src/hpc-web/src/main/resources/templates/dataobjectsearchresultdetail.html
+++ b/src/hpc-web/src/main/resources/templates/dataobjectsearchresultdetail.html
@@ -820,7 +820,7 @@ window.onclick = function(event) {
 					</div>
 					<form class="form-horizontal" id="simplesearchform" action="#"
 						role="form" th:action="@{/criteria}" th:object="${hpcSearch}"
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="actionType" name="actionType" value="pagination"/>
 						<input type="hidden" id="pageNumber" name="pageNumber"/>
 						<input type="hidden" id="pageSize" name="pageSize"/>
@@ -833,7 +833,7 @@ window.onclick = function(event) {
 					</form> 
 					<form class="form-horizontal" id="downloadFilesform" action="#"
 						role="form" th:action="@{/downloadfiles}" 
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="selectedFilePaths1" name="selectedFilePaths" value=""/>
 						<input type="hidden" id="downloadType" name="downloadType" value=""/>
 						<input type="hidden" id="searchType" name="searchType" value=""/>
@@ -846,7 +846,7 @@ window.onclick = function(event) {
 					</form> 
 					<form class="form-horizontal" id="linkFilesform" action="#"
 						role="form" th:action="@{/linkfiles}" 
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="selectedFilePaths2" name="selectedFilePaths" value=""/>
 						<input type="hidden" id="searchType2" name="searchType" value=""/>
 						<input type="hidden" id="pageNumber2" name="pageNumber"/>
@@ -858,7 +858,7 @@ window.onclick = function(event) {
 					</form> 
 					<form class="form-horizontal" id="bulkPermissionsform" action="#"
 						role="form" th:action="@{/bulkpermissions}" 
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="selectedFilePaths3" name="selectedFilePaths" value=""/>
 						<input type="hidden" id="downloadType3" name="downloadType" value=""/>
 						<input type="hidden" id="searchType3" name="searchType" value=""/>
@@ -871,7 +871,7 @@ window.onclick = function(event) {
 					</form> 
 					<form class="form-horizontal" id="bulkMetadataform" action="#"
 						role="form" th:action="@{/bulkupdatemetadata}"
-						method="post" enctype="multipart/form-data">
+						method="post">
 						<input type="hidden" id="selectedFilePaths4" name="selectedFilePaths" value=""/>
 						<input type="hidden" id="downloadType4" name="downloadType" value=""/>
 						<input type="hidden" id="searchType4" name="searchType" value=""/>
@@ -885,7 +885,7 @@ window.onclick = function(event) {
 					</form>
 					<form class="form-horizontal" id="editsearchform" action="#"
 						role="form" th:action="@{/editSearch}" th:object="${hpcSearch}"
-						method="post" enctype="multipart/form-data">
+						method="post">
 					</form> 
 				</div>
 				<!--/col-->

--- a/src/hpc-web/src/main/resources/templates/permissionbulk.html
+++ b/src/hpc-web/src/main/resources/templates/permissionbulk.html
@@ -113,8 +113,7 @@
 										<div class="col-md-12 form-group">
 											<form class="form-horizontal" id="permissionsform" action="#"
 												role="form" th:action="@{/assignbulkpermissions}"
-												th:object="${permissions}" method="POST"
-												enctype="multipart/form-data">
+												th:object="${permissions}" method="POST">
 												<input type="hidden" th:field="*{type}" />
 												<input type="hidden" name="downloadType" id="downloadType"
 													th:value="${hpcDownloadDatafile.downloadType}" />

--- a/src/hpc-web/src/main/resources/templates/reports.html
+++ b/src/hpc-web/src/main/resources/templates/reports.html
@@ -194,7 +194,7 @@ body.loading .overlay{
 
 				<form  id="reportsform" action="#"
 					role="form" th:action="@{/reports}" th:object="${reportRequest}"
-					method="post" enctype="multipart/form-data">
+					method="post">
 					
 					<!-- First Row Begin -->
 					<div class="row">

--- a/src/hpc-web/src/main/resources/templates/subscribenotifications.html
+++ b/src/hpc-web/src/main/resources/templates/subscribenotifications.html
@@ -93,7 +93,7 @@
 								<div class="panel-body">
 									<form class="form-horizontal" th:action="@{/subscribe}"
 										id="notificationRequest" th:object="${notificationRequest}"
-										method="post" enctype="multipart/form-data">
+										method="post">
 										<div class="form-group">
 
                             <div class="col-sm-10 column" style="margin-bottom: 8px"

--- a/src/hpc-web/src/main/resources/templates/updatemetadatabulk.html
+++ b/src/hpc-web/src/main/resources/templates/updatemetadatabulk.html
@@ -128,8 +128,7 @@
 										<div class="col-md-12 form-group">
 											<form class="form-horizontal" id="updateform" action="#"
 												role="form" th:action="@{/assignbulkmetadata}"
-												th:object="${bulkMetadataUpdateRequest}" method="POST"
-												enctype="multipart/form-data">
+												th:object="${bulkMetadataUpdateRequest}" method="POST">
 												<input type="hidden" name="updateAll" id="updateAll"
 													th:value="${updateAll}" />
 												<input type="hidden" name="totalCount" id="totalCount"


### PR DESCRIPTION
In collection permission page, adding new users to permissions list when the list gets long resulted in "HTTP - 413 Payload Too Large" Error. This was resolved and tested. The following form submission also does not need to use multipart/form-data and therefore was removed.
- Collection permissions
- Data object permissions
- Manage -> Notifications
- Reports
- Search
- Collection Search result
- Data object Search result
- Bulk Permissions
- Bulk Metadata Update
