### PR TITLE
HPCDATAMGM-2211: Add human readable format to file size in browse screen

### DIFF
--- a/src/hpc-web/src/main/java/gov/nih/nci/hpc/web/controller/HpcBrowseController.java
+++ b/src/hpc-web/src/main/java/gov/nih/nci/hpc/web/controller/HpcBrowseController.java
@@ -650,6 +650,7 @@ public class HpcBrowseController extends AbstractHpcController {
 					listChildEntry.setId(listEntry.getPath());
 					listChildEntry.setName(listEntry.getPath());
 					listChildEntry.setFileSize(Long.toString(listEntry.getDataSize()));
+					listChildEntry.setHumanReadableFileSize(MiscUtil.addHumanReadableSize(Long.valueOf(listEntry.getDataSize()).toString(), true));
                     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
                     if(listEntry.getCreatedAt() != null)
                       listChildEntry.setLastUpdated(sdf.format(listEntry.getCreatedAt().getTime()));

--- a/src/hpc-web/src/main/java/gov/nih/nci/hpc/web/controller/HpcBrowseController.java
+++ b/src/hpc-web/src/main/java/gov/nih/nci/hpc/web/controller/HpcBrowseController.java
@@ -675,6 +675,7 @@ public class HpcBrowseController extends AbstractHpcController {
 					listChildEntry.setId(listEntry.getPath());
 					listChildEntry.setName(listEntry.getPath());
 					listChildEntry.setFileSize(Long.toString(listEntry.getDataSize()));
+					listChildEntry.setHumanReadableFileSize(MiscUtil.addHumanReadableSize(Long.valueOf(listEntry.getDataSize()).toString(), true));
 					SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 					if(listEntry.getCreatedAt() != null)
 					  listChildEntry.setLastUpdated(sdf.format(listEntry.getCreatedAt().getTime()));

--- a/src/hpc-web/src/main/resources/templates/browse.html
+++ b/src/hpc-web/src/main/resources/templates/browse.html
@@ -96,9 +96,11 @@ app
 	        cellTemplate: '<div class="ui-grid-cell-contents folder" ng-if="row.entity.collection" ng-click="grid.appScope.openFolder(row.entity);" ><i class="fa fa-folder"></i>{{COL_FIELD CUSTOM_FILTERS}}<img class="softlink" ng-if="row.entity.softlink" src="img/link-hyperlink-icon.svg" width="13" title="Soft Link"/><div id="processingIcon{{row.entity.id}}" style="display:inline-block; visibility:hidden" class="loader"></div></div><div class="ui-grid-cell-contents file" ng-if="!row.entity.collection" >{{COL_FIELD CUSTOM_FILTERS}}<img class="softlink" ng-if="row.entity.softlink" src="img/link-hyperlink-icon.svg" width="13" title="Soft Link"/></div>'
 	      },
 	      {
-	        field : 'humanReadableFileSize',
+	        field : 'fileSize',
 	        width: '21%',
 	        displayName : 'Size',
+	        type: 'number',
+	        cellTemplate: '<div class="ui-grid-cell-contents">{{row.entity.humanReadableFileSize || row.entity.fileSize}}</div>',
             enableFiltering: false
 	      },
 	      {

--- a/src/hpc-web/src/main/resources/templates/browse.html
+++ b/src/hpc-web/src/main/resources/templates/browse.html
@@ -96,9 +96,9 @@ app
 	        cellTemplate: '<div class="ui-grid-cell-contents folder" ng-if="row.entity.collection" ng-click="grid.appScope.openFolder(row.entity);" ><i class="fa fa-folder"></i>{{COL_FIELD CUSTOM_FILTERS}}<img class="softlink" ng-if="row.entity.softlink" src="img/link-hyperlink-icon.svg" width="13" title="Soft Link"/><div id="processingIcon{{row.entity.id}}" style="display:inline-block; visibility:hidden" class="loader"></div></div><div class="ui-grid-cell-contents file" ng-if="!row.entity.collection" >{{COL_FIELD CUSTOM_FILTERS}}<img class="softlink" ng-if="row.entity.softlink" src="img/link-hyperlink-icon.svg" width="13" title="Soft Link"/></div>'
 	      },
 	      {
-	        field : 'fileSize',
+	        field : 'humanReadableFileSize',
+	        width: '21%',
 	        displayName : 'Size',
-	        type: 'number',
             enableFiltering: false
 	      },
 	      {
@@ -109,6 +109,7 @@ app
 	      {
             field : 'fullPath',
             displayName : 'Download',
+            width: '11%',
             cellFilter : 'dmePathEncoding',
             cellTemplate : '<div class="ui-grid-cell-contents" ng-if="row.entity.name.length != 0"><a id="downloadlink" class="btn btn-link btn-sm" ng-if="row.entity.collection" href="../download?type=collection&amp;path={{COL_FIELD CUSTOM_FILTERS}}&amp;source=browse"><i class="fa fa-download" aria-hidden="true"></i></a><a id="downloadlink" class="btn btn-link btn-sm" ng-if="!row.entity.collection" href="../download?type=datafile&amp;downloadFilePath={{COL_FIELD CUSTOM_FILTERS}}&amp;source=browse"><i class="fa fa-download" aria-hidden="true"></i></a></div>',
             exporterSuppressExport : true,


### PR DESCRIPTION
This ticket is to display the size of the files (in the File Size column of the File Table) on the browse screen in human readable format also. Presently, it is displayed in bytes only, which is not instantly decipherable for large files. 